### PR TITLE
Add azure upload pluggin

### DIFF
--- a/plugins/file-upload/README.md
+++ b/plugins/file-upload/README.md
@@ -39,3 +39,30 @@ interface UploadToS3BucketData {
 }
 ```
 [Upload to Amazon S3 Example Message](./docs/AmazonS3.message.json)
+
+
+## Upload to Microsoft Azure Storage
+Allows users to upload a file to an Azure Storage Containers using a [Shared acces Signature](https://docs.microsoft.com/es-es/rest/api/storageservices/delegate-access-with-shared-access-signature)   
+The Plugin will need a presigned `sasSignature`, a `baseUrl` and the `containerName` to create a URL for uploading the file, the same URL can be use to download the file after uploading it, if the timeout property from the Custom Module didn't make the URL invalid.
+
+
+### Message Data Structure
+```typescript
+interface UploadToAzureContainer {
+   _plugin: {
+       type: 'file-upload',
+       service: 'azure',
+       
+       // Base url to build the request 
+       baseURL,
+       
+       // Shared Access Signature token
+       sasSignature,
+       
+       // Name of the container where the file will be uploaded
+       containerName,
+   }
+}
+
+
+

--- a/plugins/file-upload/src/helpers/upload.js
+++ b/plugins/file-upload/src/helpers/upload.js
@@ -9,7 +9,20 @@ export const upload = async (config, file) => {
                 method: 'PUT',
                 body: file
             })
-            .then(() => downloadUrl)
+                .then(() => downloadUrl)
+        }
+        case 'azure': {
+            const { baseURL, sasSignature, containerName } = config;
+            const uploadUrl =  baseURL+containerName+'/'+file.name+sasSignature
+            const downloadUrl = uploadUrl;
+            return fetch(uploadUrl, {
+                method: 'PUT',
+                body: file,
+                headers: {
+                    'x-ms-blob-type': 'BlockBlob'
+                },
+            })
+                .then(() => downloadUrl )
         }
     }
 }

--- a/plugins/file-upload/src/index.jsx
+++ b/plugins/file-upload/src/index.jsx
@@ -82,7 +82,7 @@ const FileUpload = props => {
                 ...dialogStyles
             }}
         >
-            {service === 'amazon-s3' && (
+            {(service === 'amazon-s3' || 'azure') && (
                 <>
                     <header style={headerStyles}>
                         {titleText || 'File Upload'}


### PR DESCRIPTION
This Plugin will generate a file upload drag/choose when the custom module for azure file upload node is used, it will upload the file to a created container as a 'Blob' object.

To test, use the Custom Module 'file-upload-plugin' and choose the "Upload To Azure Container'' Node to upload a file through the Webchat