### PR TITLE
bug/26686 add error handling and success message to file upload plugin

### DIFF
--- a/plugins/file-upload/src/helpers/upload.js
+++ b/plugins/file-upload/src/helpers/upload.js
@@ -11,7 +11,13 @@ export const upload = async (config, file) => {
 			return fetch(uploadUrl, {
 				method: "PUT",
 				body: file,
-			}).then(() => downloadUrl);
+			})
+				.then(() => {
+					return { success: true, url: downloadUrl };
+				})
+				.catch(err => {
+					return { success: false, reason: `Upload failed. Error: ${err.message}` };
+				});
 		}
 		case "azure": {
 			const { baseURL, sasSignature, containerName } = config;
@@ -24,7 +30,13 @@ export const upload = async (config, file) => {
 				headers: {
 					"x-ms-blob-type": "BlockBlob",
 				},
-			}).then(() => downloadUrl);
+			})
+				.then(() => {
+					return { success: true, url: downloadUrl };
+				})
+				.catch(err => {
+					return { success: false, reason: `Upload failed. Error: ${err.message}` };
+				});
 		}
 		case "live-agent": {
 			const { inboxIdentifier, host, conversationId, contactIdentifier } = config;
@@ -43,7 +55,10 @@ export const upload = async (config, file) => {
 					return { success: true, url: res.data.attachments[0].data_url };
 				})
 				.catch(err => {
-					return { success: false, reason: err };
+					return {
+						success: false,
+						reason: `Your file upload failed. Please verify your file is less than 40MB large and is of type jpg, jpeg, png, pdf, doc or docx.`,
+					};
 				});
 		}
 	}

--- a/plugins/file-upload/src/helpers/upload.js
+++ b/plugins/file-upload/src/helpers/upload.js
@@ -1,46 +1,50 @@
-import Axios from 'axios'
-import FormData from 'form-data'
+import Axios from "axios";
+import FormData from "form-data";
 
 export const upload = async (config, file) => {
-    const { service } = config;
+	const { service } = config;
 
-    switch (service) {
-        case 'amazon-s3': {
-            const { uploadUrl, downloadUrl } = config;
+	switch (service) {
+		case "amazon-s3": {
+			const { uploadUrl, downloadUrl } = config;
 
-            return fetch(uploadUrl, {
-                method: 'PUT',
-                body: file
-            })
-                .then(() => downloadUrl)
-        }
-        case 'azure': {
-            const { baseURL, sasSignature, containerName } = config;
-            const uploadUrl =  baseURL+containerName+'/'+file.name+sasSignature
-            const downloadUrl = uploadUrl;
+			return fetch(uploadUrl, {
+				method: "PUT",
+				body: file,
+			}).then(() => downloadUrl);
+		}
+		case "azure": {
+			const { baseURL, sasSignature, containerName } = config;
+			const uploadUrl = baseURL + containerName + "/" + file.name + sasSignature;
+			const downloadUrl = uploadUrl;
 
-            return fetch(uploadUrl, {
-                method: 'PUT',
-                body: file,
-                headers: {
-                    'x-ms-blob-type': 'BlockBlob'
-                },
-            })
-                .then(() => downloadUrl)
-        }
-        case 'live-agent': {
-            const { inboxIdentifier, host, conversationId, contactIdentifier } = config;
-            const uploadUrl = `${host}/public/api/v1/inboxes/${inboxIdentifier}/contacts/${contactIdentifier}/conversations/${conversationId}/messages`;
-            const form = new FormData();
-            form.append('attachments[]', file);
-            form.append('content', 'file successfully uploaded');
+			return fetch(uploadUrl, {
+				method: "PUT",
+				body: file,
+				headers: {
+					"x-ms-blob-type": "BlockBlob",
+				},
+			}).then(() => downloadUrl);
+		}
+		case "live-agent": {
+			const { inboxIdentifier, host, conversationId, contactIdentifier } = config;
+			const uploadUrl = `${host}/public/api/v1/inboxes/${inboxIdentifier}/contacts/${contactIdentifier}/conversations/${conversationId}/messages`;
+			const form = new FormData();
+			form.append("attachments[]", file);
+			form.append("content", "file successfully uploaded");
 
-            return Axios.post(uploadUrl, form, {
-                headers: {
-                    'Content-Type': 'multipart/form-data',
-                    'Accept': '*/*',
-                },
-            }).then(res => res.data.attachments[0].data_url)           
-         }
-    }
-}
+			return Axios.post(uploadUrl, form, {
+				headers: {
+					"Content-Type": "multipart/form-data",
+					Accept: "*/*",
+				},
+			})
+				.then(res => {
+					return { success: true, url: res.data.attachments[0].data_url };
+				})
+				.catch(err => {
+					return { success: false, reason: err };
+				});
+		}
+	}
+};

--- a/plugins/file-upload/src/index.jsx
+++ b/plugins/file-upload/src/index.jsx
@@ -41,10 +41,7 @@ const FileUpload = props => {
 				});
 				props.onSendMessage("File upload succeeded", {});
 			} else {
-				props.onSendMessage(
-					`Your file upload failed. Please verify your file is less than 40MB large and is of type jpg, jpeg, png, pdf, doc or docx.`,
-					{},
-				);
+				props.onSendMessage(result.reason, {});
 			}
 		} catch (e) {
 			console.error("uploading file failed", e);

--- a/plugins/file-upload/src/index.jsx
+++ b/plugins/file-upload/src/index.jsx
@@ -14,6 +14,7 @@ let pluginBusy = false;
 const FileUpload = props => {
 	const [isUploading, setIsUploading] = React.useState(false);
 	const [isRejected, setIsRejected] = React.useState(false);
+	const [errorMessage, setErrorMessage] = React.useState(null);
 
 	const { isFullscreen, onSetFullscreen, theme, message } = props;
 
@@ -40,8 +41,9 @@ const FileUpload = props => {
 					file: result.url,
 				});
 				props.onSendMessage("File upload succeeded", {});
+				setErrorMessage(null);
 			} else {
-				props.onSendMessage(result.reason, {});
+				setErrorMessage(result.reason);
 			}
 		} catch (e) {
 			console.error("uploading file failed", e);
@@ -60,6 +62,8 @@ const FileUpload = props => {
 				`File exceeds max file size of ${sizeLimit} MB. Choose another file.`}
 		</label>
 	);
+
+	const ErrorLabel = () => <label style={errorMessageStyles}>{errorMessage}</label>;
 
 	if (!isFullscreen) {
 		const { openDialogButtonStyles } = getStylesMemo(theme);
@@ -99,6 +103,7 @@ const FileUpload = props => {
 								<p>{dropLabel || "Drag a file here, or click to select one"}</p>
 							)}
 							{isRejected ? <SizeLimitError /> : null}
+							{errorMessage ? <ErrorLabel /> : null}
 						</main>
 						<footer style={footerStyles}>
 							<button

--- a/plugins/file-upload/src/index.jsx
+++ b/plugins/file-upload/src/index.jsx
@@ -1,10 +1,10 @@
-import 'idempotent-babel-polyfill';
-import * as React from 'react';
-import memoize from 'memoize-one';
+import "idempotent-babel-polyfill";
+import * as React from "react";
+import memoize from "memoize-one";
 
-import { getStyles } from './styles';
-import { upload } from './helpers/upload'
-import { useDropzone } from 'react-dropzone';
+import { getStyles } from "./styles";
+import { upload } from "./helpers/upload";
+import { useDropzone } from "react-dropzone";
 
 // only re-calculate if theme changed
 const getStylesMemo = memoize(getStyles);
@@ -12,178 +12,155 @@ const getStylesMemo = memoize(getStyles);
 let pluginBusy = false;
 
 const FileUpload = props => {
-    const [isUploading, setIsUploading] = React.useState(false);
-    const [isRejected, setIsRejected] = React.useState(false);
+	const [isUploading, setIsUploading] = React.useState(false);
+	const [isRejected, setIsRejected] = React.useState(false);
 
-    const {
-        isFullscreen,
-        onSetFullscreen,
-        theme,
-        message,
-    } = props;
+	const { isFullscreen, onSetFullscreen, theme, message } = props;
 
-    const {
-        openButtonLabel,
-        sizeLimit,
-        fileSizeLimitErrorMessage
-    } = message.data._plugin;
+	const { openButtonLabel, sizeLimit, fileSizeLimitErrorMessage } = message.data._plugin;
+	// handles change events for the file input
+	// starts the upload
+	const onDrop = React.useCallback(async files => {
+		const file = files[0];
 
-    // handles change events for the file input
-    // starts the upload
-    const onDrop = React.useCallback(async files => {
-        const file = files[0];
+		if (file.size > sizeLimit * 1000 * 1000) {
+			setIsRejected(true);
+			return;
+		}
 
-        if (file.size > sizeLimit * 1000 * 1000) {
-            setIsRejected(true);
-            return;
-        }
+		setIsRejected(false);
+		try {
+			setIsUploading(true);
+			pluginBusy = true;
+			const result = await upload(props.message.data._plugin, file);
+			setIsUploading(false);
+			pluginBusy = false;
+			if (result.success) {
+				props.onSendMessage("", {
+					file: result.url,
+				});
+				props.onSendMessage("File upload succeeded", {});
+			} else {
+				props.onSendMessage(
+					`Your file upload failed. Please verify your file is less than 40MB large and is of type jpg, jpeg, png, pdf, doc or docx.`,
+					{},
+				);
+			}
+		} catch (e) {
+			console.error("uploading file failed", e);
+			setIsUploading(false);
+		}
+	}, []);
 
-        setIsRejected(false);
-        try {
-            setIsUploading(true);
-            pluginBusy = true;
-            const downloadUrl = await upload(props.message.data._plugin, file);
-            setIsUploading(false);
-            pluginBusy = false;
-            props.onSendMessage('', {
-                file: downloadUrl
-            });
-        } catch (e) {
-            console.error('uploading file failed', e)
-            setIsUploading(false);
-        }
-    }, []);
+	// provides handlers for drag and drop mechanics
+	const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 
-    // provides handlers for drag and drop mechanics
-    const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
+	const { errorMessageStyles } = getStylesMemo(theme);
 
-    const {
-        errorMessageStyles,
-    } = getStylesMemo(theme);
+	const SizeLimitError = () => (
+		<label style={errorMessageStyles}>
+			{fileSizeLimitErrorMessage ||
+				`File exceeds max file size of ${sizeLimit} MB. Choose another file.`}
+		</label>
+	);
 
-    const SizeLimitError = () => (
-        <label style={errorMessageStyles}>
-            {fileSizeLimitErrorMessage || `File exceeds max file size of ${sizeLimit} MB. Choose another file.`}
-        </label>
-    );
+	if (!isFullscreen) {
+		const { openDialogButtonStyles } = getStylesMemo(theme);
 
+		return (
+			<button type="button" onClick={onSetFullscreen} style={openDialogButtonStyles}>
+				{openButtonLabel || "upload file"}
+			</button>
+		);
+	}
 
-    if (!isFullscreen) {
-        const { openDialogButtonStyles } = getStylesMemo(theme);
+	const { attributes, onDismissFullscreen } = props;
 
-        return (
-            <button
-                type='button'
-                onClick={onSetFullscreen}
-                style={openDialogButtonStyles}
-            >
-                {openButtonLabel || 'upload file'}
-            </button>
-        )
-    }
+	const { service, titleText, dragClickLabel, dropLabel, cancelButtonLabel } =
+		message.data._plugin;
 
-    const {
-        attributes,
-        onDismissFullscreen,
-    } = props;
+	const { dialogStyles, headerStyles, contentStyles, footerStyles, cancelButtonStyles } =
+		getStylesMemo(theme);
 
-    const {
-        service,
-        titleText,
-        dragClickLabel,
-        dropLabel,
-        cancelButtonLabel,
-    } = message.data._plugin;
-
-    const {
-        dialogStyles,
-        headerStyles,
-        contentStyles,
-        footerStyles,
-        cancelButtonStyles
-    } = getStylesMemo(theme);
-
-    return (
-        <div
-            {...attributes}
-            style={{
-                ...attributes.styles,
-                ...dialogStyles
-            }}
-        >
-            {(service === 'amazon-s3' || service === 'azure' || service === 'live-agent') &&
-                (!isUploading && !pluginBusy ? (
-                    <>
-                        <header style={headerStyles}>{titleText || 'File Upload'}</header>
-                        <main style={contentStyles} {...getRootProps()}>
-                            <input {...getInputProps()} />
-                            {isDragActive ? (
-                                <p>{dragClickLabel || 'Drop the file here'}</p>
-                            ) : (
-                                    <p>{dropLabel || 'Drag a file here, or click to select one'}</p>
-                                )}
-                            {isRejected ? (
-                                <SizeLimitError />
-                            ) : null}
-                        </main>
-                        <footer style={footerStyles}>
-                            <button
-                                type='button'
-                                onClick={onDismissFullscreen}
-                                style={cancelButtonStyles}
-                            >
-                                {cancelButtonLabel || 'cancel'}
-                            </button>
-                        </footer>
-                    </>
-                ) : (
-                        <>
-                            <header style={headerStyles}>{titleText || 'File Upload'}</header>
-                            <Spinner theme={theme} />
-                        </>
-                    ))}
-        </div>
-    );
+	return (
+		<div
+			{...attributes}
+			style={{
+				...attributes.styles,
+				...dialogStyles,
+			}}
+		>
+			{(service === "amazon-s3" || service === "azure" || service === "live-agent") &&
+				(!isUploading && !pluginBusy ? (
+					<>
+						<header style={headerStyles}>{titleText || "File Upload"}</header>
+						<main style={contentStyles} {...getRootProps()}>
+							<input {...getInputProps()} />
+							{isDragActive ? (
+								<p>{dragClickLabel || "Drop the file here"}</p>
+							) : (
+								<p>{dropLabel || "Drag a file here, or click to select one"}</p>
+							)}
+							{isRejected ? <SizeLimitError /> : null}
+						</main>
+						<footer style={footerStyles}>
+							<button
+								type="button"
+								onClick={onDismissFullscreen}
+								style={cancelButtonStyles}
+							>
+								{cancelButtonLabel || "cancel"}
+							</button>
+						</footer>
+					</>
+				) : (
+					<>
+						<header style={headerStyles}>{titleText || "File Upload"}</header>
+						<Spinner theme={theme} />
+					</>
+				))}
+		</div>
+	);
 };
 
 const Spinner = ({ theme }) => {
-    const { spinnerContainerStyles } = getStylesMemo(theme);
-    return (
-        <div style={spinnerContainerStyles}>
-            <svg
-                width='38'
-                height='38'
-                viewBox='0 0 38 38'
-                xmlns='http://www.w3.org/2000/svg'
-                stroke={theme.greyContrastColor}
-            >
-                <g fill='none' fillRule='evenodd'>
-                    <g transform='translate(1 1)' strokeWidth='2'>
-                        <circle strokeOpacity='.5' cx='18' cy='18' r='18' />
-                        <path d='M36 18c0-9.94-8.06-18-18-18'>
-                            <animateTransform
-                                attributeName='transform'
-                                type='rotate'
-                                from='0 18 18'
-                                to='360 18 18'
-                                dur='1s'
-                                repeatCount='indefinite'
-                            />
-                        </path>
-                    </g>
-                </g>
-            </svg>
-        </div>
-    );
+	const { spinnerContainerStyles } = getStylesMemo(theme);
+	return (
+		<div style={spinnerContainerStyles}>
+			<svg
+				width="38"
+				height="38"
+				viewBox="0 0 38 38"
+				xmlns="http://www.w3.org/2000/svg"
+				stroke={theme.greyContrastColor}
+			>
+				<g fill="none" fillRule="evenodd">
+					<g transform="translate(1 1)" strokeWidth="2">
+						<circle strokeOpacity=".5" cx="18" cy="18" r="18" />
+						<path d="M36 18c0-9.94-8.06-18-18-18">
+							<animateTransform
+								attributeName="transform"
+								type="rotate"
+								from="0 18 18"
+								to="360 18 18"
+								dur="1s"
+								repeatCount="indefinite"
+							/>
+						</path>
+					</g>
+				</g>
+			</svg>
+		</div>
+	);
 };
 
 const fileUploadPlugin = {
-    match: 'file-upload',
-    component: FileUpload
+	match: "file-upload",
+	component: FileUpload,
 };
 
 if (!window.cognigyWebchatMessagePlugins) {
-    window.cognigyWebchatMessagePlugins = []
+	window.cognigyWebchatMessagePlugins = [];
 }
 
 window.cognigyWebchatMessagePlugins.push(fileUploadPlugin);


### PR DESCRIPTION
This PR adds error handling to the file upload plugin working together with live agent.

How to test:
1. Create a flow with a handover to live agent
2. Chat with the agent and request a file upload from the user.
3. Click the upload link and these files:
  1. A file of the following types: png, jpg, jpeg, doc, docx, pdf below 40mb, it should show a success message
  2. A message with a different file extension, it should show the error message
  3. A file with an allowed extension that is larger than 40mb, it takes a while but should then show the error message
  4. An antivirus test file downloaded from https://www.eicar.org/download-anti-malware-testfile/ renamed to one of the allowed extensions, it should show the error message